### PR TITLE
[Camtasia And Snagit] Prepare libproxy library for use in product 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ Temporary
 /libproxy/test/url-test
 /libproxy/test/url-encode
 /utils/proxy
+
+# ignore Visual Studio 2019 Files
+/.vs
+/out
+CMakeSettings.json

--- a/libproxy/modules/config_kde.cpp
+++ b/libproxy/modules/config_kde.cpp
@@ -19,12 +19,18 @@
  ******************************************************************************/
 
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include <algorithm>
 #include <cstdlib>
 #include <cstdio>
 #include <sstream>
+
+#ifdef WIN32
+#define popen _popen
+#define pclose _pclose
+#else
+#include <unistd.h>
+#endif
 
 #include "../extension_config.hpp"
 using namespace libproxy;

--- a/libproxy/url.cpp
+++ b/libproxy/url.cpp
@@ -20,12 +20,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  *
  ******************************************************************************/
-#ifdef WIN32
-#include <io.h>
-#define open _open
-#define O_RDONLY _O_RDONLY
-#define close _close
-#endif
+
 #include <fcntl.h> // For ::open()
 #include <cstring> // For memcpy()
 #include <sstream> // For int/string conversion (using stringstream)
@@ -36,6 +31,8 @@
 
 #ifdef WIN32
 #include <io.h>
+#define open _open
+#define O_RDONLY _O_RDONLY
 #define close _close
 #define read _read
 #define SHUT_RDWR SD_BOTH


### PR DESCRIPTION
Related PR in fork source: https://github.com/libproxy/libproxy/pull/131 

With improved CMake support in Visual Studio 2019 I can successfully compile in Visual Studio using Ninja as the generator and MSVC. However, this required some small changes in the source code.
 
The change was necessary in order to enable `config_kde.cpp` to successfully compile. This was accomplished by defining WIN32 only macros for the `popen` and `pclose` methods from `unistd.h` to point to the windows `_popen` and `_pclose` functions in `stdio.h`.  While these are not 1 : 1 equivalents, for the use here they are functionally equivalent. I followed a similar pattern implemented in the `url.cpp` file found here: https://github.com/libproxy/libproxy/blob/d6990f4aaab4b947a490ab1abfd9ac6e62d66d7a/libproxy/url.cpp#L23

While examining the solution in `url.cpp`, I noticed that there was some duplication in `url.cpp` file and added some clean up to that code as well.

Finally, to keep the repository clean of the support files that get generated by Ninja and Visual Studio, I added some additional gitignore entries. 